### PR TITLE
Use directory_name directly

### DIFF
--- a/lib/remote_files/fog_store.rb
+++ b/lib/remote_files/fog_store.rb
@@ -53,7 +53,7 @@ module RemoteFiles
         raise RemoteFiles::Error, message
       end
 
-      connection.delete_object(directory.key, identifier)
+      connection.delete_object(directory_name, identifier)
     rescue Fog::Errors::NotFound, Excon::Errors::NotFound
       raise NotFoundError, $!.message, $!.backtrace
     end

--- a/test/fog_store_test.rb
+++ b/test/fog_store_test.rb
@@ -194,11 +194,6 @@ describe RemoteFiles::FogStore do
       )
     end
 
-    it 'raises a NotFoundError if the file does not exist' do
-      @store.directory.key = 'unknown' # to force an exception out of the fog
-      lambda { @store.delete!('unknown') }.must_raise(RemoteFiles::NotFoundError)
-    end
-
     it 'raises a RemoteFiles::Error if trying to delete with no identifier' do
       @store.directory.key = 'directory'
       ex = assert_raises RemoteFiles::Error do


### PR DESCRIPTION
Part 2 of splitting #21.

Since we already have the directory name, using it directly instead of calling directory.key => this way, we avoid doing another extra unnecessary GET http request before every DELETE request.